### PR TITLE
Changed: only run build and lint steps on branches

### DIFF
--- a/.azure-pipelines/templates/01_lint.yaml
+++ b/.azure-pipelines/templates/01_lint.yaml
@@ -3,7 +3,7 @@
 stages:
   - stage: Lint
     displayName: Lint codebase
-    condition: always()
+    condition: and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), always())
     dependsOn: []
     jobs:
       - job: lint

--- a/.azure-pipelines/templates/02_build.yaml
+++ b/.azure-pipelines/templates/02_build.yaml
@@ -3,7 +3,7 @@
 stages:
   - stage: Build
     displayName: Build images
-    condition: always()
+    condition: and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), always())
     dependsOn: []
     jobs:
       - job: build

--- a/.azure-pipelines/templates/03_push.yaml
+++ b/.azure-pipelines/templates/03_push.yaml
@@ -3,7 +3,7 @@
 stages:
   - stage: Push
     displayName: Push images to container registry
-    condition: and(contains(variables['build.sourceBranch'], 'refs/heads/master'), always())
+    condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), always())
     dependsOn: []
     jobs:
       - deployment: push_approval


### PR DESCRIPTION
What does this change do ?

- Changed: only run build and lint steps on branches

Why is this change needed ?

- No need to run these steps on master