### PR TITLE
Changed: set pr trigger false prevent duplicate builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,4 @@ push_super_ops:
 	docker push "ghcr.io/eirenauts-infra/super-ops:$$(make -s get_image_version)"
 	docker push "ghcr.io/eirenauts-infra/super-ops:latest"
 	docker logout ghcr.io
+	if [[ -e /home/vsts/.docker/config.json ]]; then rm /home/vsts/.docker/config.json; fi

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,5 +1,7 @@
 # @format
 ---
+pr: none
+
 trigger:
   batch: false
   branches:
@@ -8,8 +10,6 @@ trigger:
   tags:
     include:
       - "*"
-
-pr: false
 
 pool:
   vmImage: ubuntu-20.04

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,6 +9,8 @@ trigger:
     include:
       - "*"
 
+pr: false
+
 pool:
   vmImage: ubuntu-20.04
 


### PR DESCRIPTION
What does this change do?

- Ensures that builds only run once for PRs (not twice)

Why is it needed?

- Two builds is confusing and unecessary