### PR TITLE
Fixed: only pick up current git tag on current commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **_Fixed_**
 
 - Fixed issue where git tag was erroneously picked up on git commits without tag resulting
-in overriding of the previously tagged image with latest untagged changes [eirenauts/containers#8]
+  in overriding of the previously tagged image with latest untagged changes [eirenauts/containers#8]
 
 [eirenauts/containers#7]: https://github.com/eirenauts/containers/pull/7
 [eirenauts/containers#8]: https://github.com/eirenauts/containers/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 - Dependency `build-essential` added for access to make in image `super-ops`. [eirenauts/containers#7]
 
+**_Fixed_**
+
+- Fixed issue where git tag was erroneously picked up on git commits without tag resulting
+in overriding of the previously tagged image with latest untagged changes [eirenauts/containers#8]
+
 [eirenauts/containers#7]: https://github.com/eirenauts/containers/pull/7
+[eirenauts/containers#8]: https://github.com/eirenauts/containers/pull/8
 
 ## 1.0.0 (13.12.2020)
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -194,7 +194,7 @@ function get_short_sha() {
 }
 
 function get_git_tag() {
-    git describe --abbrev=0 --tags 2>/dev/null || echo ""
+    git tag --points-at HEAD 2>/dev/null || echo ""
 }
 
 function get_image_version() {


### PR DESCRIPTION
What does this change do ?

- Fixed: only pick up current git tag on current commit

Why is this change needed ?

- Before git tags were picked up on commits after the tag was
implemented, this is not desired behaviour